### PR TITLE
polishing: No double negations

### DIFF
--- a/E131.cpp
+++ b/E131.cpp
@@ -29,15 +29,15 @@ const byte E131::ACN_ID[12] = { 0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 
 
 /* Constructor */
 E131::E131() {
-#ifndef DOUBLE_BUFFER
-    memset(pbuff1.raw, 0, sizeof(pbuff1.raw));
-    packet = &pbuff1;
-    pwbuff = packet;
-#else
+#ifdef DOUBLE_BUFFER
     memset(pbuff1.raw, 0, sizeof(pbuff1.raw));
     memset(pbuff2.raw, 0, sizeof(pbuff2.raw));
     packet = &pbuff1;
     pwbuff = &pbuff2;
+#else
+    memset(pbuff1.raw, 0, sizeof(pbuff1.raw));
+    packet = &pbuff1;
+    pwbuff = packet;
 #endif
 
     stats.num_packets = 0;

--- a/E131.cpp
+++ b/E131.cpp
@@ -29,14 +29,12 @@ const byte E131::ACN_ID[12] = { 0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 
 
 /* Constructor */
 E131::E131() {
-#ifdef DOUBLE_BUFFER
     memset(pbuff1.raw, 0, sizeof(pbuff1.raw));
-    memset(pbuff2.raw, 0, sizeof(pbuff2.raw));
     packet = &pbuff1;
+#ifdef DOUBLE_BUFFER
+    memset(pbuff2.raw, 0, sizeof(pbuff2.raw));
     pwbuff = &pbuff2;
 #else
-    memset(pbuff1.raw, 0, sizeof(pbuff1.raw));
-    packet = &pbuff1;
     pwbuff = packet;
 #endif
 

--- a/E131.cpp
+++ b/E131.cpp
@@ -29,7 +29,7 @@ const byte E131::ACN_ID[12] = { 0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 
 
 /* Constructor */
 E131::E131() {
-#ifdef NO_DOUBLE_BUFFER
+#ifndef DOUBLE_BUFFER
     memset(pbuff1.raw, 0, sizeof(pbuff1.raw));
     packet = &pbuff1;
     pwbuff = packet;

--- a/E131.h
+++ b/E131.h
@@ -32,6 +32,7 @@
 #   define _UDP WiFiUDP
 #   define INT_ESP8266
 #   define INT_WIFI
+#   define DOUBLE_BUFFER
 #elif defined (ARDUINO_ARCH_AVR)
 #   include <Ethernet.h>
 #   include <EthernetUdp.h>
@@ -39,7 +40,6 @@
 #   include <utility/util.h>
 #   define _UDP EthernetUDP
 #   define INT_ETHERNET
-#   define NO_DOUBLE_BUFFER
 #endif
 
 /* Defaults */
@@ -139,7 +139,7 @@ class E131 {
     static const uint8_t VECTOR_DMP = 2;
 
     e131_packet_t   pbuff1;     /* Packet buffer */
-#ifndef NO_DOUBLE_BUFFER
+#ifdef DOUBLE_BUFFER
     e131_packet_t   pbuff2;     /* Double buffer */
 #endif
     e131_packet_t   *pwbuff;    /* Pointer to working packet buffer */
@@ -211,7 +211,7 @@ class E131 {
             udp.readBytes(pwbuff->raw, size);
             error = validate();
             if (!error) {
-#ifndef NO_DOUBLE_BUFFER
+#ifdef DOUBLE_BUFFER
                 e131_packet_t *swap = packet;
                 packet = pwbuff;
                 pwbuff = swap;

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library is to simplify the validation and handling of E1.31 sACN (DMX over 
 ### API / Usage
 #### Notes
 - Double-buffering of packet data is disabled on AVR architectures due to memory constraints.  Make sure to check the return value of ```parsePacket()``` as your buffer may be trashed if a bad packet made its way in.
-- Other architectures (i.e. ESP8266) double buffer the packets, so ```e131.data``` can always be considered pristine.  Double buffering can be disabled by defining ```NO_DOUBLE_BUFFER``` in ```E131.h```.
+- Other architectures (i.e. ESP8266) double buffer the packets, so ```e131.data``` can always be considered pristine.  Double buffering can be disabled by removing the ```DOUBLE_BUFFER``` #define-ition in ```E131.h```.
 - WiFi connection attempts will timeout after 10 seconds if a successful connection has not been established.  ```WIFI_CONNECT_TIMEOUT``` can be changed in ```E131.h```.
 
 #### Initializers


### PR DESCRIPTION
Hi Forkineye,

I'm very grateful to your excellent E131 code; I'm reading it to learn how to handle my own E131 on a [particle photon](https://www.particle.io/products/hardware/photon-wifi-dev-kit).

In doing so, I kept struggling with the double negations around `#ifndef NO_DOUBLE_BUFFER`.
I've decided to flip it around for less confusion, and wanted to offer it up to you as "upstream", in case you might find it useful.

If you find it useful, please feel free to take it, I put this contribution into the public domain, so that you may use it in whatever way you see fit.

Thank you for the excellent library, I am going to fiddle with it further :-)