### PR TITLE
extract universe-to-multicastIP calculation to (public) function

### DIFF
--- a/E131.cpp
+++ b/E131.cpp
@@ -53,19 +53,23 @@ void E131::initUnicast() {
     }
 }
 
+IPAddress E131::multicastIPFor(uint16_t universe) {
+    return IPAddress(239, 255,
+            ((universe >> 8) & 0xff),
+            ((universe >> 0) & 0xff)
+    );
+}
+
 void E131::initMulticast(uint16_t universe, uint8_t n) {
     delay(100);
-    IPAddress address = IPAddress(239, 255, ((universe >> 8) & 0xff),
-            ((universe >> 0) & 0xff));
+    IPAddress address = multicastIPFor(universe);
 #ifdef INT_ESP8266
     ip_addr_t ifaddr;
     ip_addr_t multicast_addr;
 
     ifaddr.addr = static_cast<uint32_t>(WiFi.localIP());
     for (uint8_t i = 1; i < n; i++) {
-        multicast_addr.addr = static_cast<uint32_t>(IPAddress(239, 255,
-                (((universe + i) >> 8) & 0xff), (((universe + i) >> 0)
-                & 0xff)));
+        multicast_addr.addr = static_cast<uint32_t>(MulticastIPFor(universe + i));
         igmp_joingroup(&ifaddr, &multicast_addr);
     }
 

--- a/E131.h
+++ b/E131.h
@@ -160,6 +160,9 @@ class E131 {
 
     E131();
 
+    /* Maps a DMX universe to the correct multicast IP */
+    IPAddress multicastIPFor(uint16_t universe);
+
     /* Generic UDP listener, no physical or IP configuration */
     void begin(e131_listen_t type, uint16_t universe = 1, uint8_t n = 1);
 


### PR DESCRIPTION
Some more "refactoring-to-understand"... If it is useful, please enjoy it; if you think it unusable, feel free to decline!

I am learning very much from your work, and noticed that I needed this function in my own programming, because I do my own initialisation of the WiFi, outside E131.

Before I keep "spamming" you with more pull requests; is this a type of contribution you are interested in at all?
I wish to "contribute back" for the great resource you have created, but if you are not interested in such tiny polishings (some might call it "[gold plating](https://en.wikipedia.org/wiki/Gold_plating_(software_engineering))" ;-) ), I will of course stop. Your call!