### PR TITLE
Add implementation for sACN Multicast for Ethernet Shield

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Visual Micro/
 *.vcxproj*
 *.sln
 *.suo
+.development
+E131.ino

--- a/E131.cpp
+++ b/E131.cpp
@@ -235,7 +235,44 @@ void E131::begin(uint8_t *mac, IPAddress ip, IPAddress netmask,
 
 /* Multicast Ethernet Initializers */
 int E131::beginMulticast(uint8_t *mac, uint16_t universe, uint8_t n) {
-    //TODO: Add ethernet multicast support
+    int retval = 0;
+
+    if (Serial) {
+        Serial.println("");
+        Serial.println(F("Requesting Address via DHCP"));
+        Serial.print(F("- MAC: "));
+        for (int i = 0; i < 6; i++)
+            Serial.print(mac[i], HEX);
+        Serial.println("");
+    }
+
+    retval = Ethernet.begin(mac);
+
+    if (Serial) {
+        if (retval) {
+            Serial.print(F("- IP Address: "));
+            Serial.println(Ethernet.localIP());
+        } else {
+            Serial.println(F("** DHCP FAILED"));
+        }
+    }
+
+    if (retval) {
+        delay(100);
+        IPAddress address = IPAddress(239, 255, ((universe >> 8) & 0xff),
+                ((universe >> 0) & 0xff));
+    
+        retval = udp.beginMulticast(address, E131_DEFAULT_PORT);
+        
+        if (Serial) {
+            if (retval) 
+              Serial.println(F("- Multicast Enabled"));
+            else
+              Serial.println(F("- Failed to enable Multicast"));
+        }
+    }
+
+    return retval;
 }
 
 void E131::beginMulticast(uint8_t *mac, uint16_t universe,

--- a/E131.h
+++ b/E131.h
@@ -147,10 +147,16 @@ class E131 {
 
     /* Internal Initializers */
     int initWiFi(const char *ssid, const char *passphrase);
-    int initEthernet(uint8_t *mac, IPAddress ip, IPAddress netmask,
-            IPAddress gateway, IPAddress dns);
     void initUnicast();
+
+#if defined (INT_ETHERNET)
+    int initDHCP(uint8_t *mac);
+    void initStaticIP(uint8_t *mac, IPAddress ip, IPAddress netmask,
+        IPAddress gateway, IPAddress dns);
+    int initMulticast(uint16_t universe, uint8_t n = 1);
+#elif
     void initMulticast(uint16_t universe, uint8_t n = 1);
+#endif
 
  public:
     uint8_t       *data;                /* Pointer to DMX channel data */
@@ -192,7 +198,7 @@ class E131 {
 
     /* Multicast Ethernet Initializers */
     int beginMulticast(uint8_t *mac, uint16_t universe, uint8_t n = 1);
-    void beginMulticast(uint8_t *mac, uint16_t universe,
+    int beginMulticast(uint8_t *mac, uint16_t universe,
             IPAddress ip, IPAddress netmask, IPAddress gateway,
             IPAddress dns, uint8_t n = 1);
 #endif

--- a/utility/util.h
+++ b/utility/util.h
@@ -1,0 +1,24 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+#ifndef htons
+#define htons(x) ( ((x)<< 8 & 0xFF00) | \
+                   ((x)>> 8 & 0x00FF) )
+#endif
+
+#ifndef ntohs
+#define ntohs(x) htons(x)
+#endif
+
+#ifndef htonl
+#define htonl(x) ( ((x)<<24 & 0xFF000000UL) | \
+                   ((x)<< 8 & 0x00FF0000UL) | \
+                   ((x)>> 8 & 0x0000FF00UL) | \
+                   ((x)>>24 & 0x000000FFUL) )
+#endif
+
+#ifndef ntohl
+#define ntohl(x) htonl(x)
+#endif
+
+#endif


### PR DESCRIPTION
This pull request adds an implementation for two defined but unimplemented methods:
- `int E131::beginMulticast(uint8_t *mac, uint16_t universe)`
- `int E131::beginMulticast(uint8_t *mac, uint16_t universe, IPAddress ip, IPAddress netmask, IPAddress gateway, IPAddress dns)`

It also adds the missing `utility/util.h` file